### PR TITLE
fix entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,5 @@ ADD . $CC_CLI_HOME/antcc/
 ENV ANTCC_HOME=$CC_CLI_HOME/antcc
 ENV PATH=$PATH:$ANTCC_HOME/bin
 
-ENTRYPOINT antcc
+ENTRYPOINT ["antcc"]
 CMD ["help"]
-
-RUN antcc help


### PR DESCRIPTION
as from docker site:
Note: If CMD is used to provide default arguments for the ENTRYPOINT instruction, both the CMD and ENTRYPOINT instructions should be specified with the JSON array format.